### PR TITLE
Permalink to the current curation template

### DIFF
--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.views.generic.base import RedirectView
 
 from . import views
 
@@ -27,5 +28,8 @@ urlpatterns = [
     path('docs/', views.DocsView.as_view(), name='Documentation'),
 
     # ex: /downloads/
-    path('downloads/', views.DownloadView.as_view(), name='Downloads')
+    path('downloads/', views.DownloadView.as_view(), name='Downloads'),
+
+    #ex: /template/current
+    path('template/current', RedirectView.as_view(url='https://docs.google.com/spreadsheets/d/1CGZUhxRraztW4k7p_6blfBmFndYTcmghn3iNnzJu1_0/edit?usp=sharing'))
 ]

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.views.generic.base import RedirectView
 
 from . import views
 
@@ -31,5 +30,5 @@ urlpatterns = [
     path('downloads/', views.DownloadView.as_view(), name='Downloads'),
 
     #ex: /template/current
-    path('template/current', RedirectView.as_view(url='https://docs.google.com/spreadsheets/d/1CGZUhxRraztW4k7p_6blfBmFndYTcmghn3iNnzJu1_0/edit?usp=sharing'))
+    path('template/current', views.CurrentTemplateView.as_view(), name='Current Curation Template')
 ]

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -1,6 +1,8 @@
 from django.http import Http404
 from django.shortcuts import render
 from django.views.generic import TemplateView
+from django.views.generic.base import RedirectView
+from django.conf import settings
 from django.db.models.functions import Lower
 import re
 
@@ -265,3 +267,6 @@ class DocsView(TemplateView):
 
 class DownloadView(TemplateView):
     template_name = "catalog/download.html"
+
+class CurrentTemplateView(RedirectView):
+    url = settings.USEFUL_URLS['TEMPLATEGoogleDoc_URL']

--- a/pgs_web/settings.py
+++ b/pgs_web/settings.py
@@ -93,7 +93,8 @@ USEFUL_URLS = {
     'PGS_CONTACT'    : 'pgs-info@ebi.ac.uk',
     'PGS_FTP_ROOT'   : 'ftp://ftp.ebi.ac.uk/pub/databases/spot/pgs',
     'PGS_TWITTER_URL': 'https://www.twitter.com/pgscatalog',
-    'UOC_URL'        : 'https://www.phpc.cam.ac.uk/'
+    'UOC_URL'        : 'https://www.phpc.cam.ac.uk/',
+    'TEMPLATEGoogleDoc_URL' : 'https://docs.google.com/spreadsheets/d/1CGZUhxRraztW4k7p_6blfBmFndYTcmghn3iNnzJu1_0/edit?usp=sharing'
 }
 
 WSGI_APPLICATION = 'pgs_web.wsgi.application'


### PR DESCRIPTION
Now we can give the URL: www.pgscatalog.org/template/current to link to the current PGS Catalog Curation Template

In the future it might be useful to also have www.pgscatalog.org/template/extraction_guidelines, etc. 

