### PR TITLE
Fix/downgrade numpy

### DIFF
--- a/requirements_local.txt
+++ b/requirements_local.txt
@@ -21,6 +21,7 @@ google-cloud-storage==2.4.0
 
 #### Data import ####
 pandas==1.5.3
+numpy==1.26.0
 
 #### For webpage testing ####
 django-debug-toolbar==4.2.0

--- a/requirements_local.txt
+++ b/requirements_local.txt
@@ -22,6 +22,7 @@ google-cloud-storage==2.4.0
 #### Data import ####
 pandas==1.5.3
 numpy==1.26.0
+openpyxl==3.1.4
 
 #### For webpage testing ####
 django-debug-toolbar==4.2.0


### PR DESCRIPTION
Just-released [numpy 2.0.0](https://numpy.org/news/#numpy-200-released) is causing the following error with pandas and needs to be downgraded to the previous version at the moment:

> ImportError: Failed to import test module: test_import
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/unittest/loader.py", line 419, in _find_test_path
    module = self._get_module_from_name(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/unittest/loader.py", line 362, in _get_module_from_name
    __import__(name)
  File "/home/runner/work/PGS_Catalog/PGS_Catalog/curation/tests/test_import.py", line 2, in <module>
    from curation.imports.curation import CurationImport
  File "/home/runner/work/PGS_Catalog/PGS_Catalog/curation/imports/curation.py", line 1, in <module>
    import pandas as pd
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/pandas/__init__.py", line 22, in <module>
    from pandas.compat import is_numpy_dev as _is_numpy_dev  # pyright: ignore # noqa:F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/pandas/compat/__init__.py", line 18, in <module>
    from pandas.compat.numpy import (
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/pandas/compat/numpy/__init__.py", line 4, in <module>
    from pandas.util.version import Version
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/pandas/util/__init__.py", line 2, in <module>
    from pandas.util._decorators import (  # noqa:F401
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/pandas/util/_decorators.py", line 14, in <module>
    from pandas._libs.properties import cache_readonly
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/pandas/_libs/__init__.py", line 13, in <module>
    from pandas._libs.interval import Interval
  File "pandas/_libs/interval.pyx", line 1, in init pandas._libs.interval
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject