### PR TITLE
Fix CSP "nonce" not being refreshed if the page is loaded from backend cache

### DIFF
--- a/catalog/cache/remove_nonce.py
+++ b/catalog/cache/remove_nonce.py
@@ -1,0 +1,22 @@
+from django.core.cache.backends.locmem import LocMemCache
+import re
+
+
+class RemoveNonceFromCacheBackend(LocMemCache):
+    """If a page is cached on the server and contains CSP nonces, the value of the nonce
+    if not refreshed making it not matching the nonce any new HTTP response header, and
+    more problematically giving the same nonce to all clients. This subclass removes
+    the nonce completely from a cached page, which will be put back downstream by the
+    middleware with the correct value of the new request."""
+    def get(self, key, default=None, version=None):
+        result = super().get(key, default, version)
+        if result is not None:
+            if key.startswith('views.decorators.cache.cache_page') and hasattr(result, 'content'):
+                # Remove every html nonce="..." attribute from cached content
+                result.content = re.sub(
+                        r' nonce="[^"]+"',
+                        '',
+                        result.content.decode('utf-8'),
+                        flags=re.IGNORECASE
+                    ).encode('utf-8')
+        return result

--- a/catalog/cache/remove_nonce.py
+++ b/catalog/cache/remove_nonce.py
@@ -11,7 +11,9 @@ class RemoveNonceFromCacheBackend(LocMemCache):
     def get(self, key, default=None, version=None):
         result = super().get(key, default, version)
         if result is not None:
-            if key.startswith('views.decorators.cache.cache_page') and hasattr(result, 'content'):
+            if (key.startswith('views.decorators.cache.cache_page')
+                    and hasattr(result, 'content')
+                    and 'text/html' in result.get('Content-Type', '')):
                 # Remove every html nonce="..." attribute from cached content
                 result.content = re.sub(
                         r' nonce="[^"]+"',

--- a/pgs_web/settings.py
+++ b/pgs_web/settings.py
@@ -117,6 +117,12 @@ if not DEBUG:
         'csp.middleware.CSPMiddleware',
         'catalog.middleware.add_nonce.AddNonceToScriptsMiddleware'
     ])
+    CACHES = {
+        'default': {
+            # Custom cache class called if cache_page decorator is used
+            'BACKEND': 'catalog.cache.remove_nonce.RemoveNonceFromCacheBackend',
+        }
+    }
 
 CSP_INCLUDE_NONCE_IN = [
     'script-src'

--- a/pgs_web/settings.py
+++ b/pgs_web/settings.py
@@ -158,6 +158,7 @@ CSP_IMG_SRC = ("'self'",
                )
 # front-src
 CSP_FONT_SRC = ("'self'",
+                "data:",
                 get_base_url(STYLES_URLS['font-awesome']),
                 get_base_url(STYLES_URLS['ebi']))
 # connect-src


### PR DESCRIPTION
The CSP "`nonce`" was not refreshed if a page is cached on the server using the `cache_page` decorator. The "nonce" is now removed from cached content to be added back with the proper value.