### PR TITLE
Added Google Analytics domains to CSP connect and img src

### DIFF
--- a/pgs_web/settings.py
+++ b/pgs_web/settings.py
@@ -154,7 +154,10 @@ CSP_SCRIPT_SRC = ("'self'",
                   )
 # img-src
 CSP_IMG_SRC = ("'self'",
-               "data:"  # For SVG images
+               "data:",  # For SVG images
+               # Google Analytics
+               'https://*.google-analytics.com',
+               'https://*.googletagmanager.com'
                )
 # front-src
 CSP_FONT_SRC = ("'self'",
@@ -164,7 +167,11 @@ CSP_FONT_SRC = ("'self'",
 # connect-src
 CSP_CONNECT_SRC = ("'self'",
                    USEFUL_URLS['EBI_URL'],
-                   USEFUL_URLS['PGS_WEBSITE_URL'])
+                   USEFUL_URLS['PGS_WEBSITE_URL'],
+                   # Google Analytics
+                   'https://*.google-analytics.com',
+                   'https://*.analytics.google.com',
+                   'https://*.googletagmanager.com')
 
 # Live middleware
 if PGS_ON_LIVE_SITE:

--- a/rest_api/templates/rest_api/rest_doc.html
+++ b/rest_api/templates/rest_api/rest_doc.html
@@ -49,9 +49,7 @@
           layout: "StandaloneLayout",
           useUnsafeMarkdown: true,
           defaultModelsExpandDepth: 0, // Collapse the Schemas section by default (set to 0). Hide the Schemas section if it's set to -1.
-          {% if is_pgs_live_site == False %}
-            validatorUrl: 'none' // Hide the validator badge at the bottom of the page.
-          {% endif %}
+          validatorUrl: 'none' // Hide the validator badge at the bottom of the page.
         })
         // End Swagger UI call region
         window.ui = ui


### PR DESCRIPTION
This one went under radar as most non-Chrome web browsers block Analytics by default, hiding the potential CSP error.
GA scripts are already covered by 'strict-dynamic' and 'nonce', although this doesn't include connections and images called from those external scripts.

Following [these recommendations](https://developers.google.com/tag-platform/security/guides/csp).