### PR TITLE
Added redirects package

### DIFF
--- a/pgs_web/settings.py
+++ b/pgs_web/settings.py
@@ -76,6 +76,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',  # necessary for redirects
+    'django.contrib.redirects',
     'django_tables2',
     'compressor',
     'rest_framework',
@@ -105,7 +107,8 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware'
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.contrib.redirects.middleware.RedirectFallbackMiddleware'
 ]
 
 # ----------------------------- #
@@ -452,3 +455,11 @@ MIN_UPLOAD_SIZE=1000
 MAX_UPLOAD_SIZE=2000000
 MAX_UPLOAD_SIZE_LABEL="2Mb"
 DATA_UPLOAD_MAX_NUMBER_FILES=10
+
+
+#----------#
+#  Others  #
+#----------#
+
+# Site default ID, necessary for django.contrib.sites.
+SITE_ID = 1


### PR DESCRIPTION
So that requests to publication/PGS000080 get redirected to publication/PGP000080.
Doesn't apply for REST API requests. Requests for rest/publication/PGS000080 will return empty '{}'.

Needs the following execution:

```
python manage.py migrate sites
python manage.py migrate redirects
```

And the following python script:
```
from django.contrib.sites.models import Site
from django.contrib.redirects.models import Redirect

default_site = Site.objects.get(id=1)
default_site.domain = 'pgscatalog.org'
default_site.name = 'PGS Catalog'
default_site.save()

redirects = [
    ['/publication/PGS000080/', '/publication/PGP000080/']
]

for r in redirects:
    redirect = Redirect.objects.create(
        site=default_site,
        old_path=r[0],
        new_path=r[1],
    )
    redirect.save()
```
